### PR TITLE
Fix for RDoc Generation under Ruby 1.9

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,2 @@
+# encoding: UTF-8
 require "stringex"

--- a/lib/lucky_sneaks/acts_as_url.rb
+++ b/lib/lucky_sneaks/acts_as_url.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module LuckySneaks
   module ActsAsUrl # :nodoc:
     def self.included(base)

--- a/lib/lucky_sneaks/string_extensions.rb
+++ b/lib/lucky_sneaks/string_extensions.rb
@@ -1,4 +1,4 @@
-# coding: utf-8
+# encoding: UTF-8
 
 module LuckySneaks
   # These methods are all added on String class.

--- a/lib/lucky_sneaks/unidecoder.rb
+++ b/lib/lucky_sneaks/unidecoder.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "yaml"
 
 module LuckySneaks

--- a/lib/stringex.rb
+++ b/lib/stringex.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'lucky_sneaks/string_extensions'
 require 'lucky_sneaks/unidecoder'
 

--- a/test/acts_as_url_test.rb
+++ b/test/acts_as_url_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'test/unit'
 
 begin

--- a/test/string_extensions_test.rb
+++ b/test/string_extensions_test.rb
@@ -1,4 +1,4 @@
-# coding: utf-8
+# encoding: UTF-8
 
 require "test/unit"
 

--- a/test/unicode_point_suite/basic_latin_test.rb
+++ b/test/unicode_point_suite/basic_latin_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "test/unit"
 
 require File.join(File.dirname(__FILE__), "../../init")

--- a/test/unicode_point_suite/codepoint_test_helper.rb
+++ b/test/unicode_point_suite/codepoint_test_helper.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # 100% shorthand
 module CodepointTestHelper
   def assert_equal_encoded(expected, encode_mes)

--- a/test/unidecoder_test.rb
+++ b/test/unidecoder_test.rb
@@ -1,4 +1,4 @@
-# coding: utf-8
+# encoding: UTF-8
 
 require "test/unit"
 


### PR DESCRIPTION
This patch fixes Issues 7 and 8 for stringex RDoc Generation under Ruby 1.9.
