### PR TITLE
Removing slash conversion from stringex

### DIFF
--- a/lib/lucky_sneaks/string_extensions.rb
+++ b/lib/lucky_sneaks/string_extensions.rb
@@ -153,7 +153,6 @@ module LuckySneaks
         /(\s|^)¥(\d*)(\s|$)/u => '\2 yen',
         /\s*\*\s*/ => "star",
         /\s*%\s*/ => "percent",
-        /\s*(\\|\/)\s*/ => "slash",
         /(\s*=\s*)/ => " equals "
       }.each do |found, replaced|
         replaced = " #{replaced} " unless replaced =~ /\\1/


### PR DESCRIPTION
Hey there!

I've been recently using Mongoid::Slug which depends on stringex for permalink formation and was quite surprised that the / character gets converted to slash inline when I'm forming a URL since it is a valid URL character and having it in prevents the formation of nice permalinks like /2011/05/26/title-of-this-article

I'm using Mongoid::Slug to do 
slug :published_at_permalink_prefix, :title

which works great if I use dashes as the separator but which obviously messes up if I use slashes as the date separators.

Was trying to think of use cases where you wouldn't want a / in the URL as a permalink even if it was in the title (even though that's a pretty rare use case I'd imaging) and couldn't after racking my brain a little so just figured it might be better to remove it and ask for the pull request.

Made the change and issuing the pull request, though if there is a very good reason it's in there, let me know. Just figured you were being very thorough.  =] 

ciao !
Daryl.
