### PR TITLE
Use the Syck parser. Psych is not really working. 

### DIFF
--- a/lib/lucky_sneaks/unidecoder.rb
+++ b/lib/lucky_sneaks/unidecoder.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require "yaml"
+YAML::ENGINE.yamler= 'syck'
 
 module LuckySneaks
   module Unidecoder


### PR DESCRIPTION
On file unidecoder_data/x00.yml I get:

```
Psych::SyntaxError: couldn't parse YAML at line 2 column 3
```

So just changing the parser, everything works.
