### PR TITLE
verify_local_codepoints checks if arg is a Hash

### DIFF
--- a/lib/stringex/unidecoder.rb
+++ b/lib/stringex/unidecoder.rb
@@ -115,7 +115,7 @@ module Stringex
       # Checks LOCAL_CODEPOINTS's Hash is in the format we expect before assigning it and raises
       # instructive exception if not
       def verify_local_codepoints(hash)
-        pass_check = hash.all?{|key, value|
+        pass_check = hash.is_a?(Hash) && hash.all?{|key, value|
           # Fuck a duck, eh?
           [Symbol, String].include?(key.class) && value.is_a?(Hash) &&
             value.keys.all?{|k| k.is_a?(String)} && value.values.all?{|v| v.is_a?(String)}


### PR DESCRIPTION
When I tried to run test suite, it fell with the following message:

``` raw
test_bad_localize_from_file(UnidecoderLocalizationAliasTest) [stringex/test/unidecoder_localization_alias_test.rb:59]:
[ArgumentError] exception expected, not
Class: <NoMethodError>
Message: <"undefined method `all?' for \"Anything not correct\":String">
---Backtrace---
stringex/lib/stringex/unidecoder.rb:118:in `verify_local_codepoints'
stringex/lib/stringex/unidecoder.rb:52:in `localize_from'
stringex/lib/stringex/unidecoder.rb:144:in `block (2 levels) in singletonclass'
stringex/test/unidecoder_localization_alias_test.rb:59:in `block in test_bad_localize_from_file'
---------------
```

It seems that the `YAML#load_file` method returns `String` instead of `Hash` for the bad_unidecoder_localization.yml file.
Maybe it's worth to check if `verify_local_codepoints` method gets `Hash` as an argument before the validation of hash's structure.
