### PR TITLE
Documentation for initialize_urls

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,6 +28,8 @@ In order to use the generated url attribute, you will probably want to override 
 
 Routing called via named routes like <tt>foo_path(@foo)</tt> will automatically use the url. In your controllers you will need to call <tt>Foo.find_by_url(params[:id])</tt> instead of the regular find. Don't look for <tt>params[:url]</tt> unless you set it explicitly in the routing, <tt>to_param</tt> will generate <tt>params[:id]</tt>.
 
+Note that if you add <tt>acts_as_url</tt> to an old model, the <tt>url</tt> database column will inititally be blank. To set this column for your old instances, you can use the <tt>initialize_urls</tt> method. So if your class is <tt>Post</tt>, just say <tt>Post.all.each{|p| p.initialize_urls}</tt>.
+
 Unlike other permalink solutions, ActsAsUrl doesn't rely on Iconv (which is inconsistent across platforms and doesn't provide great transliteration as is) but instead uses a transliteration scheme (see the code for Unidecoder) which produces much better results for Unicode characters. It also mixes in some custom helpers to translate common characters into a more URI-friendly format rather than just dump them completely. Examples:
 
    # A simple prelude


### PR DESCRIPTION
Documentation: Added a paragraph about using initialize_urls to set the url on old models.
