### PR TITLE
remove pipe characters from URLs

### DIFF
--- a/lib/stringex/string_extensions.rb
+++ b/lib/stringex/string_extensions.rb
@@ -162,7 +162,7 @@ module Stringex
         replaced = " #{replaced} " unless replaced =~ /\\1/
         dummy.gsub!(found, replaced)
       end
-      dummy = dummy.gsub(/(^|\w)'(\w|$)/, '\1\2').gsub(/[\.,:;()\[\]\?!\^'"_]/, " ")
+      dummy = dummy.gsub(/(^|\w)'(\w|$)/, '\1\2').gsub(/[\.,:;()\[\]\?!\^'"_\|]/, " ")
     end
 
     # Replace runs of whitespace in string. Defaults to a single space but any replacement

--- a/test/string_extensions_test.rb
+++ b/test/string_extensions_test.rb
@@ -50,7 +50,9 @@ class StringExtensionsTest < Test::Unit::TestCase
       "foo = bar and bar=foo" =>
         "foo-equals-bar-and-bar-equals-foo",
       "Will…This Work?" =>
-        "will-dot-dot-dot-this-work"
+        "will-dot-dot-dot-this-work",
+      "with a | pipe" =>
+        "with-a-pipe"
     }.each do |html, plain|
       assert_equal plain, html.to_url
     end


### PR DESCRIPTION
I have a project that uses `to_url` on page titles, which sometimes have pipes. `URI.parse` barfed. It's a legal character but should be encoded, so I figured this is the place to make the change.
