### PR TITLE
Convert divide sign too

### DIFF
--- a/lib/stringex/string_extensions.rb
+++ b/lib/stringex/string_extensions.rb
@@ -99,6 +99,7 @@ module Stringex
         "(#188|frac14)" => "one fourth",
         "(#189|frac12)" => "half",
         "(#190|frac34)" => "three fourths",
+        "(#247|divide)" => "divide",
         "(#176|deg)" => " degrees "
       }.each do |textiled, normal|
         dummy.gsub!(/&#{textiled};/, normal)
@@ -186,6 +187,7 @@ module Stringex
         /\s*%\s*/ => "percent",
         /(\s*=\s*)/ => " equals ",
         /\s*\+\s*/ => "plus",
+        /\s*÷\s*/ => "divide",
         /\s*°\s*/ => "degrees"
       }
       misc_characters[/\s*(\\|\/|／)\s*/] = 'slash' unless options[:allow_slash]

--- a/test/string_extensions_test.rb
+++ b/test/string_extensions_test.rb
@@ -67,8 +67,8 @@ class StringExtensionsTest < Test::Unit::TestCase
         "paul-cezanne",
       "21'17ʼ51" =>
         "21-17-51",
-      "ITCZ 1 (21°17ʼ51.78”N / 89°35ʼ28.18”O / 26-04-08 / 09:00 am)" =>
-        "itcz-1-21-degrees-17-51-dot-78-n-slash-89-degrees-35-28-dot-18-o-slash-26-04-08-slash-09-00-am",
+      "ITCZ÷1 (21°17ʼ51.78”N / 89°35ʼ28.18”O / 26-04-08 / 09:00 am)" =>
+        "itcz-divide-1-21-degrees-17-51-dot-78-n-slash-89-degrees-35-28-dot-18-o-slash-26-04-08-slash-09-00-am",
       "／" =>
         "slash"
     }.each do |html, plain|


### PR DESCRIPTION
Without this patch, some file with '÷' in name converted to path with directory:

``` ruby
'a÷b.doc'.to_url => 'a/b.doc'
```

It's potentially dangerous.

Related to issue #66
