### PR TITLE
Updated active_record adapter to use modern query methods

### DIFF
--- a/lib/stringex/acts_as_url/adapter/active_record.rb
+++ b/lib/stringex/acts_as_url/adapter/active_record.rb
@@ -58,7 +58,7 @@ module Stringex
         end
 
         def url_owners
-          @url_owners ||= url_owners_class.unscoped.find(:all, :conditions => url_owner_conditions)
+          @url_owners ||= url_owners_class.unscoped.where(url_owner_conditions)
         end
 
         def self.orm_class


### PR DESCRIPTION
Eliminating hordes of deprecation warnings in Rails 4, but breaks compatibility with Rails 2.
