### PR TITLE
Add link to localization wiki

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -92,6 +92,10 @@ In both the YAML and pure Hash implementation, the end result should be a Hash w
 
 A collection of extensions on Ruby's String class. Please see the documentation for StringExtensions module for more information. There's not much to explain about them really.
 
+== Localization
+
+You can localize the different conversions in Stringex. Read more here[https://github.com/rsl/stringex/wiki/Localization-of-Stringex-conversions]
+
 == Note to users of CanCan
 
 You'll need to add a <tt>:find_by => :url</tt> to your <tt>load_and_authorize_resource</tt>.  Here's an example:


### PR DESCRIPTION
This adds a link to the localization [wiki page](https://github.com/rsl/stringex/wiki/Localization-of-Stringex-conversions).
