### PR TITLE
Fix ActsAsUrl::add_new_record_url_owner_conditions failing with an sql error

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -56,7 +56,7 @@ module Stringex
 
         def add_new_record_url_owner_conditions
           return if is_new?(instance)
-          @url_owner_conditions.first << " and id != ?"
+          @url_owner_conditions.first << " and #{instance.class.primary_key} != ?"
           @url_owner_conditions << instance.id
         end
 


### PR DESCRIPTION
This happens in case table does not have an "id" column - the patch changes hard-coded "id" to an instance.class.primary_key method call.
