### PR TITLE
StringExtensions base settings for ActsAsUrl

### DIFF
--- a/lib/stringex/configuration/acts_as_url.rb
+++ b/lib/stringex/configuration/acts_as_url.rb
@@ -5,8 +5,6 @@ module Stringex
         if options[:scope]
           options[:scope_for_url] = options.delete(:scope)
         end
-        options = Stringex::Configuration::StringExtensions.new.default_settings.merge(options)
-
         super
       end
 
@@ -43,7 +41,7 @@ module Stringex
           :scope_for_url => nil,
           :sync_url => false,
           :url_attribute => "url",
-        }
+        }.merge(Stringex::Configuration::StringExtensions.new.default_settings)
       end
     end
   end

--- a/test/acts_as_url_configuration_test.rb
+++ b/test/acts_as_url_configuration_test.rb
@@ -37,4 +37,14 @@ class ActsAsUrlConfigurationTest < Test::Unit::TestCase
       assert_equal acts_as_url_settings.settings.send(key), string_extensions_settings.settings.send(key)
     end
   end
+
+  def test_accepts_base_settings_for_string_extensions
+    string_extensions_settings = Stringex::Configuration::StringExtensions.new.default_settings    
+
+    Stringex::ActsAsUrl.configure do |c|
+      string_extensions_settings.keys.each do |key|
+        assert_respond_to c, "#{key}="
+      end
+    end
+  end
 end


### PR DESCRIPTION
As ActsAsUrl uses StringExtensions, it would be great to be able to set its base settings through the ActAsUrl configurator. I came across two possible solutions:
1. ActsAsUrl inherits current settings from StringExtensions instead of the default settings. I've made a branch for this, but I'm not happy at all with this solution since you are forced to the same settings for both. See 06a0d86e8a1f40f09f890722a5b34bb42b663f47
2. Allow ActsAsUrl configurator to accept base settings for StringExtensions. I think is the way to go and what I'm using right now.

I'll be happy with any other solution whenever there's a way to accomplish what I explained above.
