### PR TITLE
Allow blank translations. Fixes #101

### DIFF
--- a/lib/stringex/localization.rb
+++ b/lib/stringex/localization.rb
@@ -37,7 +37,7 @@ module Stringex
 
         translation = initial_translation(scope, key, locale)
 
-        return translation unless translation.to_s.empty?
+        return translation unless translation.nil?
 
         if locale != default_locale
           translate scope, key, options.merge(:locale => default_locale)

--- a/lib/stringex/localization/backend/i18n.rb
+++ b/lib/stringex/localization/backend/i18n.rb
@@ -30,7 +30,10 @@ module Stringex
           end
 
           def initial_translation(scope, key, locale)
-            ::I18n.translate(key, :scope => [:stringex, scope], :locale => locale, :default => "")
+            # I18n can't return a nil as default as this gets interpreted as if no default
+            # is specified, so we use a string instead.
+            translated = ::I18n.translate(key, :scope => [:stringex, scope], :locale => locale, :default => "__default__")
+            translated == "__default__" ? nil : translated
           end
 
           def load_translations(locale = nil)

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -39,7 +39,7 @@ da:
       frac14: en fjerdedel
       frac12: halv
       frac34: tre fjerdedele
-      gt: >
+      gt: ">"
       lt: <
       nbsp: " "
       pound: " pund "

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -39,7 +39,7 @@ en:
       frac14: one fourth
       frac12: half
       frac34: three fourths
-      gt: >
+      gt: ">"
       lt: <
       nbsp: " "
       pound: " pounds "

--- a/test/localization_test.rb
+++ b/test/localization_test.rb
@@ -109,4 +109,15 @@ class LocalizationTest < Test::Unit::TestCase
       assert_equal value, Stringex::Localization.translate(:test_i18n_translation, key)
     end
   end
+
+  def test_allows_blank_translations
+    [:internal, :i18n].each do |backend|
+      Stringex::Localization.backend = backend
+
+      assert_equal "Test blank", "Test&nbsp;blank".convert_miscellaneous_html_entities
+
+      Stringex::Localization.store_translations :en, :html_entities, { :nbsp => "" }
+      assert_equal "Testblank", "Test&nbsp;blank".convert_miscellaneous_html_entities
+    end
+  end
 end


### PR DESCRIPTION
Allow for blank translations so users can have ex `&nbsp;` converted to a blank string instead of having to specify something.
