### PR TITLE
Check for Railtie specifically

### DIFF
--- a/lib/stringex.rb
+++ b/lib/stringex.rb
@@ -12,6 +12,6 @@ String.send :extend, Stringex::StringExtensions::PublicClassMethods
 
 Stringex::ActsAsUrl::Adapter.load_available
 
-if defined?(Rails)
+if defined?(Rails::Railtie)
   require 'stringex/rails/railtie'
 end


### PR DESCRIPTION
I've got in the situation, when I have `Rails` defined without `Railtie`.
