### PR TITLE
Add note about initialize_urls only populating NULL URLs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,7 +36,7 @@ In order to use the generated url attribute, you will probably want to override 
 
 Routing called via named routes like <tt>foo_path(@foo)</tt> will automatically use the url. In your controllers you will need to call <tt>Foo.find_by_url(params[:id])</tt> instead of the regular find. Don't look for <tt>params[:url]</tt> unless you set it explicitly in the routing, <tt>to_param</tt> will generate <tt>params[:id]</tt>.
 
-Note that if you add <tt>acts_as_url</tt> to an existing model, the <tt>url</tt> database column will initially be blank. To set this column for your existing instances, you can use the <tt>initialize_urls</tt> method. So if your class is <tt>Post</tt>, just say <tt>Post.initialize_urls</tt>.
+Note that if you add <tt>acts_as_url</tt> to an existing model, the <tt>url</tt> database column will initially be blank. To set this column for your existing instances, you can use the <tt>initialize_urls</tt> method. So if your class is <tt>Post</tt>, just say <tt>Post.initialize_urls</tt>. Note, though, that this will only initialize instances where the <tt>url</tt> column is NULL. Empty strings don't count. So when adding your column, be sure to allow NULLs.
 
 Unlike other permalink solutions, ActsAsUrl doesn't rely on Iconv (which is inconsistent across platforms and doesn't provide great transliteration as is) but instead uses a transliteration scheme (see the code for Unidecoder) which produces much better results for Unicode characters. It also mixes in some custom helpers to translate common characters into a more URI-friendly format rather than just dump them completely. Examples:
 


### PR DESCRIPTION
I just spent a short while wondering why calling `.initialize_urls` on my model was silently doing nothing. It was because when I added the column, I made it NOT NULL, so the URLs were initialized to empty strings, which are not returned by [`klass_previous_instances`](https://github.com/rsl/stringex/blob/ef196f92d88267b5402c4b37154cab733a763eec/lib/stringex/acts_as_url/adapter/active_record.rb#L14), so are not auto-populated. This pull request doesn't change that behavior, but adds a note to the README to hopefully help others avoid the same gotcha.
