### PR TITLE
Fix the allow_slash option

### DIFF
--- a/lib/stringex/localization.rb
+++ b/lib/stringex/localization.rb
@@ -77,7 +77,7 @@ module Stringex
       end
 
       def convert(string, options = {}, &block)
-        converter = Converter.new(string)
+        converter = Converter.new(string, options)
         converter.instance_exec &block
         converter.smart_strip!
         converter.string

--- a/lib/stringex/localization/conversion_expressions.rb
+++ b/lib/stringex/localization/conversion_expressions.rb
@@ -25,7 +25,7 @@ module Stringex
       }
 
       # Things that just get converted to spaces
-      CLEANUP_CHARACTERS = /[\.,:;(){}\[\]\/\?!\^'ʼ"_\|]/
+      CLEANUP_CHARACTERS = /[\.,:;(){}\[\]\?!\^'ʼ"_\|]/
       CLEANUP_HTML_ENTITIES = /&[^;]+;/
 
       CURRENCIES_SUPPORTED_SIMPLE = {

--- a/lib/stringex/string_extensions.rb
+++ b/lib/stringex/string_extensions.rb
@@ -52,7 +52,7 @@ module Stringex
       # you should run any methods which convert HTML entities (convert_accented_html_entities and convert_miscellaneous_html_entities)
       # before running this method.
       def convert_miscellaneous_characters(options = {})
-        stringex_convert do
+        stringex_convert(options) do
           translate! :ellipses, :currencies, :abbreviations, :characters, :apostrophes
           cleanup_characters!
         end

--- a/test/acts_as_url_integration_test.rb
+++ b/test/acts_as_url_integration_test.rb
@@ -308,4 +308,22 @@ class ActsAsUrlIntegrationTest < Test::Unit::TestCase
     @doc_2 = AnotherSTIChildDocument.create(:title => "Unique")
     assert_equal "unique-1", @doc_2.url
   end
+
+  def test_should_strip_slashes_by_default
+    Document.class_eval do
+      acts_as_url :title
+    end
+
+    @doc = Document.create(:title => "a b/c d")
+    assert_equal "a-b-slash-c-d", @doc.url
+  end
+
+  def test_should_allow_slashes_to_be_allowed
+    Document.class_eval do
+      acts_as_url :title, :allow_slash => true
+    end
+
+    @doc = Document.create(:title => "a b/c d")
+    assert_equal "a-b/c-d", @doc.url
+  end
 end


### PR DESCRIPTION
This option doesn't appear to be working at all right now, at least for the ActiveRecord adaptor. It appears to be because the `options` hash isn't passed any deeper than `convert_miscellaneous_characters`, so by the time slashes are being replaced, only the default options are applied.
