### PR TITLE
require 'stringex/unidecoder' can be used alone,also require 'stringex/core_ext'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,7 +85,16 @@ Note: No offense is intended to the author[s] of whatever plugins might produce 
 
 This library converts Unicode [and accented ASCII] characters to their plain-text ASCII equivalents. This is a port of Perl's Unidecode and provides eminently superior and more reliable results than Iconv. (Seriously, Iconv... A plague on both your houses! [sic])
 
-You probably won't ever need to run Unidecoder by itself. StringExtensions adds String#to_ascii which wraps all of Unidecoder's functionality. For anyone interested, details of the implementation can be read about in the original implementation of Text::Unidecode[http://interglacial.com/~sburke/tpj/as_html/tpj22.html]. Extensive examples can be found in the tests.
+You may require only the unidecoder (and its dependent localization) via
+
+  require "stringex/unidecoder"
+
+You probably won't ever need to run Unidecoder by itself. Thus, you probably would want to add String#to_ascii which wraps all of Unidecoder's functionality, by requiring:
+
+  require "stringex/core_ext"
+
+For anyone interested, details of the implementation can be read about in the original implementation of Text::Unidecode[http://interglacial.com/~sburke/tpj/as_html/tpj22.html]. Extensive examples can be found in the tests.
+
 
 == StringExtensions
 

--- a/lib/stringex.rb
+++ b/lib/stringex.rb
@@ -8,8 +8,7 @@ require 'stringex/unidecoder'
 require 'stringex/acts_as_url'
 require 'stringex/version'
 
-String.send :include, Stringex::StringExtensions::PublicInstanceMethods
-String.send :extend, Stringex::StringExtensions::PublicClassMethods
+require 'stringex/core_ext'
 
 Stringex::ActsAsUrl::Adapter.load_available
 

--- a/lib/stringex/core_ext.rb
+++ b/lib/stringex/core_ext.rb
@@ -1,0 +1,10 @@
+Stringex = Module.new unless defined?(Stringex)
+ensure_module_defined = ->(base, module_name){
+  base.const_set(module_name, Module.new) unless base.const_defined?(module_name)
+}
+ensure_module_defined[Stringex, :StringExtensions]
+ensure_module_defined[Stringex::StringExtensions, :PublicInstanceMethods]
+ensure_module_defined[Stringex::StringExtensions, :PublicClassMethods]
+
+String.send :include, Stringex::StringExtensions::PublicInstanceMethods
+String.send :extend, Stringex::StringExtensions::PublicClassMethods

--- a/lib/stringex/unidecoder.rb
+++ b/lib/stringex/unidecoder.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require 'yaml'
+require 'stringex/localization'
 
 module Stringex
   module Unidecoder
@@ -68,12 +69,14 @@ module Stringex
 end
 
 module Stringex
-  module StringExtensions::PublicInstanceMethods
-    # Returns string with its UTF-8 characters transliterated to ASCII ones. Example:
-    #
-    #   "⠋⠗⠁⠝⠉⠑".to_ascii #=> "france"
-    def to_ascii
-      Stringex::Unidecoder.decode(self)
+  module StringExtensions
+    module PublicInstanceMethods
+      # Returns string with its UTF-8 characters transliterated to ASCII ones. Example:
+      #
+      #   "⠋⠗⠁⠝⠉⠑".to_ascii #=> "france"
+      def to_ascii
+        Stringex::Unidecoder.decode(self)
+      end
     end
   end
 end

--- a/test/unit/unidecoder_test.rb
+++ b/test/unit/unidecoder_test.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 require "test_helper"
-require "stringex"
+require "stringex/unidecoder"
 
 class UnidecoderTest < Test::Unit::TestCase
   # Silly phrases courtesy of Frank da Cruz
@@ -61,6 +61,7 @@ class UnidecoderTest < Test::Unit::TestCase
   end
 
   def test_to_ascii
+    require "stringex/core_ext"
     DONT_CONVERT.each do |ascii|
       assert_equal ascii, ascii.to_ascii
     end


### PR DESCRIPTION
Closes #162
