### PR TITLE
Minor rewrite of slug generation duplicate check.

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -18,7 +18,7 @@ module Stringex
         end
 
         def ensure_unique_url!(instance)
-          @url_owners = nil
+          @test_urls = nil
           self.instance = instance
 
           handle_url!
@@ -119,10 +119,12 @@ module Stringex
         end
 
         def handle_duplicate_url!
-          return if url_owners.none?{|owner| url_attribute_for(owner) == base_url}
-          n = 1
-          while url_owners.any?{|owner| url_attribute_for(owner) == duplicate_for_base_url(n)}
-            n = n.succ
+          return if test_urls.none?{|test_url| test_url == base_url}
+          max_id = test_urls.collect { |test_url| test_url =~ /(\d+)\Z/ && $1.to_i }.compact.max
+          if max_id
+            n = max_id.succ
+          else
+            n = 1
           end
           write_url_attribute duplicate_for_base_url(n)
         end
@@ -188,8 +190,8 @@ module Stringex
           @url_owner_conditions
         end
 
-        def url_owners
-          @url_owners ||= url_owners_class.unscoped.where(url_owner_conditions).to_a
+        def test_urls
+          @test_urls ||= url_owners_class.unscoped.where(url_owner_conditions).pluck(settings.url_attribute)
         end
 
         def url_owners_class


### PR DESCRIPTION
1. Uses "pluck" to pull only the slug column rather than instantiating
   all objects.
2. Assumes that the slug ends with a serial number, finds the highest
   such serial number, and adds 1 to it
3. This change should make acts_as_url usable for large datasets.
