### PR TITLE
Support ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.2.0
   - 2.1.1
   - 1.9.3
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,8 @@ group :development do
   gem 'travis-lint', '1.7.0'
   # Can I state that I really dislike camelcased gem names?
   gem 'RedCloth', '4.2.9'
-  gem 'sqlite3', '1.3.7'
+  gem 'sqlite3', '1.3.10'
+  gem 'test-unit', '3.0.9'
 
   if activerecord?
     gem 'activerecord', '4.0.3'

--- a/stringex.gemspec
+++ b/stringex.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Russell Norris"]
-  s.date = "2014-04-09"
+  s.date = "2015-02-18"
   s.description = "Some [hopefully] useful extensions to Ruby's String class. Stringex is made up of three libraries: ActsAsUrl [permalink solution with better character translation], Unidecoder [Unicode to ASCII transliteration], and StringExtensions [miscellaneous helper methods for the String class]."
   s.email = "rsl@luckysneaks.com"
   s.extra_rdoc_files = [
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
     "lib/stringex/configuration/configurator.rb",
     "lib/stringex/configuration/string_extensions.rb",
     "lib/stringex/configuration_lite.rb",
+    "lib/stringex/core_ext.rb",
     "lib/stringex/localization.rb",
     "lib/stringex/localization/backend/base.rb",
     "lib/stringex/localization/backend/i18n.rb",
@@ -233,6 +234,7 @@ Gem::Specification.new do |s|
     "locales/da.yml",
     "locales/de.yml",
     "locales/en.yml",
+    "locales/fr.yml",
     "locales/nl.yml",
     "locales/pl.yml",
     "locales/pt-BR.yml",
@@ -250,6 +252,7 @@ Gem::Specification.new do |s|
     "test/unit/localization/de_test.rb",
     "test/unit/localization/default_test.rb",
     "test/unit/localization/en_test.rb",
+    "test/unit/localization/fr_test.rb",
     "test/unit/localization/nl_test.rb",
     "test/unit/localization/pl_test.rb",
     "test/unit/localization/pt_br_test.rb",
@@ -270,7 +273,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/rsl/stringex"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc", "--charset", "utf-8", "--line-numbers"]
-  s.rubygems_version = "2.2.2"
+  s.rubygems_version = "2.4.5"
   s.summary = "Some [hopefully] useful extensions to Ruby's String class"
 
   if s.respond_to? :specification_version then
@@ -280,14 +283,16 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["= 2.0.1"])
       s.add_development_dependency(%q<travis-lint>, ["= 1.7.0"])
       s.add_development_dependency(%q<RedCloth>, ["= 4.2.9"])
-      s.add_development_dependency(%q<sqlite3>, ["= 1.3.7"])
+      s.add_development_dependency(%q<sqlite3>, ["= 1.3.10"])
+      s.add_development_dependency(%q<test-unit>, ["= 3.0.9"])
       s.add_development_dependency(%q<activerecord>, ["= 4.0.3"])
       s.add_development_dependency(%q<i18n>, ["= 0.6.9"])
     else
       s.add_dependency(%q<jeweler>, ["= 2.0.1"])
       s.add_dependency(%q<travis-lint>, ["= 1.7.0"])
       s.add_dependency(%q<RedCloth>, ["= 4.2.9"])
-      s.add_dependency(%q<sqlite3>, ["= 1.3.7"])
+      s.add_dependency(%q<sqlite3>, ["= 1.3.10"])
+      s.add_dependency(%q<test-unit>, ["= 3.0.9"])
       s.add_dependency(%q<activerecord>, ["= 4.0.3"])
       s.add_dependency(%q<i18n>, ["= 0.6.9"])
     end
@@ -295,7 +300,8 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<jeweler>, ["= 2.0.1"])
     s.add_dependency(%q<travis-lint>, ["= 1.7.0"])
     s.add_dependency(%q<RedCloth>, ["= 4.2.9"])
-    s.add_dependency(%q<sqlite3>, ["= 1.3.7"])
+    s.add_dependency(%q<sqlite3>, ["= 1.3.10"])
+    s.add_dependency(%q<test-unit>, ["= 3.0.9"])
     s.add_dependency(%q<activerecord>, ["= 4.0.3"])
     s.add_dependency(%q<i18n>, ["= 0.6.9"])
   end


### PR DESCRIPTION
This commit adds support for ruby 2.2.0, including:
* adding test-unit as a development dependency now that it's removed from stdlib
* upgrading the sqlite3 dependency
* adding ruby 2.2.0 to the travis-ci matrix