### PR TITLE
Add url_taken_method option for overriding url collision logic

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -119,12 +119,20 @@ module Stringex
         end
 
         def handle_duplicate_url!
-          return if url_owners.none?{|owner| url_attribute_for(owner) == base_url}
+          return if !url_taken?(base_url)
           n = 1
-          while url_owners.any?{|owner| url_attribute_for(owner) == duplicate_for_base_url(n)}
+          while url_taken?(duplicate_for_base_url(n))
             n = n.succ
           end
           write_url_attribute duplicate_for_base_url(n)
+        end
+
+        def url_taken?(url)
+          if settings.url_taken_method
+            instance.send(settings.url_taken_method, url)
+          else
+            url_owners.any?{|owner| url_attribute_for(owner) == url}
+          end
         end
 
         def handle_url!

--- a/test/unit/acts_as_url_integration_test.rb
+++ b/test/unit/acts_as_url_integration_test.rb
@@ -376,4 +376,17 @@ class ActsAsUrlIntegrationTest < Test::Unit::TestCase
     @doc = Document.create(:title => "title with many whole words")
     assert_equal 'title-with-many', @doc.url
   end
+
+  def test_should_allow_overriding_url_taken_method
+    Document.class_eval do
+      acts_as_url :title, :url_taken_method => :url_taken?
+
+      def url_taken?(url)
+        ["unique", "unique-1", "unique-2"].include?(url)
+      end
+    end
+
+    @doc = Document.create(:title => "unique")
+    assert_equal "unique-3", @doc.url
+  end
 end


### PR DESCRIPTION
I want to supply my own method that decides whether a given url candidate is unique or not. Our use-case is that we are also storing histories of urls, for which we do redirects, and we don't want collisions with those as well.

Example:
```
class Document
  acts_as_url :title, url_taken_method: :url_taken?

  def url_taken?(url)
    Document.where(url: url).where("id != ?, id).any? ||
      OtherThingy.where(url: url).any?
  end
end
```

Let me know your thoughts :)