### PR TITLE
Wrapped "no" in single-quotes

### DIFF
--- a/locales/no.yml
+++ b/locales/no.yml
@@ -3,7 +3,7 @@
 # Stringex::Localization::ConversionExpressions to see what those
 # regular expressions look like if you need to manipulate the order
 # differently than the usage below.
-no:
+'no':
   stringex:
     characters:
       and: og


### PR DESCRIPTION
This prevents it from being evaluated by YAML as "false".

See: http://makandracards.com/makandra/24809-yaml-keys-like-yes-or-no-evaluate-to-true-and-false