### PR TITLE
add support for removing not human readable control characters

### DIFF
--- a/lib/stringex/localization/conversion_expressions.rb
+++ b/lib/stringex/localization/conversion_expressions.rb
@@ -103,6 +103,8 @@ module Stringex
         /…/ => "...",
       }
 
+      UNREADABLE_CONTROL_CHARACTERS = /[[:cntrl:]]/
+
       # Ordered by denominator then numerator of the value
       VULGAR_FRACTIONS = {
         :half          => /(&#189;|&frac12;|½)/,
@@ -138,6 +140,7 @@ module Stringex
           html_entities
           html_tag
           smart_punctuation
+          unreadable_control_characters
           vulgar_fractions
           whitespace
         }.each do |conversion_type|

--- a/lib/stringex/localization/converter.rb
+++ b/lib/stringex/localization/converter.rb
@@ -59,7 +59,6 @@ module Stringex
         end
       end
 
-
       protected
 
       def unreadable_control_characters
@@ -106,14 +105,13 @@ module Stringex
         string.squeeze! ' '
       end
 
-
       def vulgar_fractions
         expressions.vulgar_fractions.each do |key, expression|
           string.gsub! expression, translate(key, :vulgar_fractions)
         end
       end
 
-    private
+      private
 
       def expressions
         ConversionExpressions

--- a/lib/stringex/localization/converter.rb
+++ b/lib/stringex/localization/converter.rb
@@ -59,7 +59,12 @@ module Stringex
         end
       end
 
-    protected
+
+      protected
+
+      def unreadable_control_characters
+        string.gsub! expressions.unreadable_control_characters, ''
+      end
 
       def abbreviations
         string.gsub! expressions.abbreviation do |x|
@@ -100,6 +105,7 @@ module Stringex
         end
         string.squeeze! ' '
       end
+
 
       def vulgar_fractions
         expressions.vulgar_fractions.each do |key, expression|

--- a/lib/stringex/string_extensions.rb
+++ b/lib/stringex/string_extensions.rb
@@ -93,6 +93,12 @@ module Stringex
         end
       end
 
+      def convert_unreadable_control_characters
+        stringex_convert do
+          translate! :unreadable_control_characters
+        end
+      end
+
       # Returns the string limited in size to the value of limit.
       def limit(limit = nil, truncate_words = true, whitespace_replacement_token = "-")
         if limit.nil?
@@ -126,6 +132,7 @@ module Stringex
           convert_smart_punctuation.
           convert_accented_html_entities.
           convert_vulgar_fractions.
+          convert_unreadable_control_characters.
           convert_miscellaneous_html_entities.
           convert_miscellaneous_characters(options).
           to_ascii.

--- a/test/unit/string_extensions_test.rb
+++ b/test/unit/string_extensions_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 require "test_helper"
 require "stringex"
@@ -285,12 +285,11 @@ class StringExtensionsTest < Test::Unit::TestCase
   end
 
   def test_remove_nonreadable_characters
-    cases = { "Jörg Immendor\u0014. Les théâtres de la peinture" => "jorg-immendor-les-theatres-de-la-peinture",
+    cases = { "Jörg Immendor\u0014. Les théâtres" => "jorg-immendor-les-theatres",
             }
     cases.each do |plain, converted|
       assert_equal converted, plain.to_url
     end
-
   end
 
   if defined?(RedCloth)

--- a/test/unit/string_extensions_test.rb
+++ b/test/unit/string_extensions_test.rb
@@ -284,6 +284,15 @@ class StringExtensionsTest < Test::Unit::TestCase
     end
   end
 
+  def test_remove_nonreadable_characters
+    cases = { "Jörg Immendor\u0014. Les théâtres de la peinture" => "jorg-immendor-les-theatres-de-la-peinture",
+            }
+    cases.each do |plain, converted|
+      assert_equal converted, plain.to_url
+    end
+
+  end
+
   if defined?(RedCloth)
     def test_to_html
       {


### PR DESCRIPTION
Characters caught by `/[[:cntrl:]]/` as stated in [Ruby Regexp](http://ruby-doc.org/core-1.9.3/Regexp.html) are removed from the string, as mentioned in Issue #174 