### PR TITLE
Freeze the "." character used in comparisons

### DIFF
--- a/lib/stringex/localization.rb
+++ b/lib/stringex/localization.rb
@@ -11,6 +11,9 @@ module Stringex
     include DefaultConversions
 
     class << self
+
+      DOT = ".".freeze
+      
       def backend
         @backend ||= i18n_present? ? Backend::I18n : Backend::Internal
       end
@@ -36,7 +39,7 @@ module Stringex
       end
 
       def translate(scope, key, options = {})
-        return if key == "." # I18n doesn't support dots as translation keys so we don't either
+        return if key == DOT # I18n doesn't support dots as translation keys so we don't either
 
         locale = options[:locale] || self.locale
 


### PR DESCRIPTION
(Disclaimer: this change is written by @Fred-JulieDesk, I take no credit or responsibility, I'm just the pull request creator :) )

This change freezes the `.` character that is used in comparison of the translation key. This way, we don't allocate a new string object every time the comparison is made and save a bit of memory.

See #180 for more.