### PR TITLE
Load taken urls from db instead of complete objects

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -18,7 +18,7 @@ module Stringex
         end
 
         def ensure_unique_url!(instance)
-          @url_owners = nil
+          @taken_urls = nil
           self.instance = instance
 
           handle_url!
@@ -131,7 +131,7 @@ module Stringex
           if settings.url_taken_method
             instance.send(settings.url_taken_method, url)
           else
-            url_owners.any?{|owner| url_attribute_for(owner) == url}
+            taken_urls.include?(url)
           end
         end
 
@@ -196,8 +196,8 @@ module Stringex
           @url_owner_conditions
         end
 
-        def url_owners
-          @url_owners ||= url_owners_class.unscoped.where(url_owner_conditions).to_a
+        def taken_urls
+          @taken_urls ||= url_owners_class.unscoped.where(url_owner_conditions).pluck(settings.url_attribute)
         end
 
         def url_owners_class

--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -197,7 +197,8 @@ module Stringex
         end
 
         def taken_urls
-          @taken_urls ||= url_owners_class.unscoped.where(url_owner_conditions).pluck(settings.url_attribute)
+          @taken_urls ||= url_owners_class.unscoped.where(url_owner_conditions).
+                          pluck(settings.url_attribute)
         end
 
         def url_owners_class

--- a/lib/stringex/acts_as_url/adapter/data_mapper.rb
+++ b/lib/stringex/acts_as_url/adapter/data_mapper.rb
@@ -44,8 +44,8 @@ module Stringex
           instance.attributes[attribute]
         end
 
-        def url_owners
-          @url_owners ||= url_owners_class.all(:conditions => url_owner_conditions)
+        def taken_urls
+          @taken_urls ||= url_owners_class.all(:conditions => url_owner_conditions).pluck(settings.url_attribute)
         end
 
         def read_attribute(instance, name)

--- a/lib/stringex/acts_as_url/adapter/data_mapper.rb
+++ b/lib/stringex/acts_as_url/adapter/data_mapper.rb
@@ -45,7 +45,9 @@ module Stringex
         end
 
         def taken_urls
-          @taken_urls ||= url_owners_class.all(:conditions => url_owner_conditions).pluck(settings.url_attribute)
+          @taken_urls ||= url_owners_class.
+                          all(conditions: url_owner_conditions).
+                          pluck(settings.url_attribute)
         end
 
         def read_attribute(instance, name)


### PR DESCRIPTION
**Premise**

We have a scenario where there might be 1000 records in database with the same title. When saving the 1001st one, currently acts_as_urls loads 1000 records to see which number it should append to the end of the url slug. Naturally this causes some issues with memory when there are lots of records.

**Changes made**

This PR changes it so that only the url slugs are loaded into the memory rather than complete objects.

**Few notes:**
- I'm not really familiar with the codebase but all current tests seem to pass
- Issue #176 is somewhat related, but this does not solve the problem mentioned regarding fetching _all_ records.
