### PR TITLE
Allow custom sequence to be used to generate unique URLs

### DIFF
--- a/lib/stringex/acts_as_url.rb
+++ b/lib/stringex/acts_as_url.rb
@@ -33,6 +33,11 @@ module Stringex
       #                              differentiate between urls. Default is false[y]. See note on <tt>:scope</tt>.
       # <tt>:duplicate_count_separator</tt>:: String to use when forcing unique urls from non-unique strings.
       #                                       Default is "-".
+      # <tt>:duplicate_sequence</tt>:: Supply an enumerator to generate the values used to generate
+      #                                unique urls (when <tt>:allow_duplicates</tt> is false).
+      #                                By default, generates positive integers in sequence from 1.
+      #                                <strong>Note:</strong> The sequence is restarted for each record
+      #                                (by calling <tt>#rewind</tt>).
       # <tt>:force_downcase</tt>:: If false, allows generated url to contain uppercased letters. Default is false.
       # <tt>:exclude_list</tt>:: List of complete strings that should not be transformed by <tt>acts_as_url</tt>.
       #                          Default is empty.

--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -120,11 +120,24 @@ module Stringex
 
         def handle_duplicate_url!
           return if !url_taken?(base_url)
-          n = 1
-          while url_taken?(duplicate_for_base_url(n))
-            n = n.succ
+          n = nil
+          sequence = duplicate_url_sequence.tap(&:rewind)
+          loop do
+            n = sequence.next
+            break unless url_taken?(duplicate_for_base_url(n))
           end
           write_url_attribute duplicate_for_base_url(n)
+        end
+
+        def duplicate_url_sequence
+          settings.duplicate_sequence ||
+            Enumerator.new do |enum|
+              n = 1
+              loop do
+                enum.yield n
+                n += 1
+              end
+            end
         end
 
         def url_taken?(url)

--- a/test/unit/acts_as_url_integration_test.rb
+++ b/test/unit/acts_as_url_integration_test.rb
@@ -20,6 +20,39 @@ class ActsAsUrlIntegrationTest < Test::Unit::TestCase
     assert_equal "unique-1", @other_doc.url
   end
 
+  def test_should_allow_custom_duplicates
+    sequence = Enumerator.new { |enum| loop { enum.yield 12345 } }
+    Document.class_eval do
+      acts_as_url :title, :duplicate_sequence => sequence
+    end
+
+    @doc = Document.create(:title => "New")
+    @other_doc = Document.create(:title => "New")
+    assert_equal "new-document", @doc.url
+    assert_equal "new-document-12345", @other_doc.url
+  end
+
+  def test_should_restart_duplicate_sequence_each_time
+    sequence = Enumerator.new do |enum|
+      n = 1
+      loop do
+        enum.yield n
+        n += 1
+      end
+    end
+    Document.class_eval do
+      acts_as_url :title, :duplicate_sequence => sequence
+    end
+    @doc = Document.create(:title => "Unique")
+    @other_doc = Document.create(:title => "Unique")
+    @third_doc = Document.create(:title => "Another")
+    @fourth_doc = Document.create(:title => "Another")
+    assert_equal "unique", @doc.url
+    assert_equal "unique-1", @other_doc.url
+    assert_equal "another", @third_doc.url
+    assert_equal "another-1", @fourth_doc.url
+  end
+
   def test_should_avoid_blacklist
     @doc = Document.create(:title => "New")
     @other_doc = Document.create(:title => "new")


### PR DESCRIPTION
Numbering duplicates sequentially from a known integer (e.g. `document-1`) is a possible attack vector, as it verifies the existence of previous records in the sequence. This PR adds the ability to do the following:

```ruby
acts_as_url :title, duplicate_sequence: Enum.new { |enum| loop { enum.yield rand(10000..99999) } }
```

You could put anything in there: UUID generation, hashing, anything. The only requirements are that the object you pass in behaves like an `Enumerator` insofar as it responds to `rewind` and `next`.

🎅 Merry Christmas! 🎄