### PR TITLE
Add support for nil scope values (such as deleted_at), with unit test

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -64,8 +64,10 @@ module Stringex
 
         def add_scoped_url_owner_conditions
           [settings.scope_for_url].flatten.compact.each do |scope|
-            @url_owner_conditions.first << " and #{scope} = ?"
-            @url_owner_conditions << instance.send(scope)
+            scope_val = instance.send(scope)
+            cond_sql_operator = scope_val.nil? ? 'IS' : '='
+            @url_owner_conditions.first << " AND #{scope} #{cond_sql_operator} ?"
+            @url_owner_conditions << scope_val
           end
         end
 

--- a/test/unit/acts_as_url_integration_test.rb
+++ b/test/unit/acts_as_url_integration_test.rb
@@ -177,6 +177,18 @@ class ActsAsUrlIntegrationTest < Test::Unit::TestCase
     assert_not_equal @doc.url, @other_doc.url
   end
 
+  def test_should_create_uniuque_urls_for_nil_scope_values
+    Document.class_eval do
+      acts_as_url :title, scope: [:other, :another]
+    end
+
+    @doc = Document.create(title: "Mocumentary", other: "Suddenly, I care if I'm unique",
+      another: nil)
+    @other_doc = Document.create(title: "Mocumentary", other: "Suddenly, I care if I'm unique",
+      another: nil)
+    assert_not_equal @doc.url, @other_doc.url
+  end
+
   def test_should_allow_setting_url_attribute
     Document.class_eval do
       # Manually undefining the url method on Document which, in a real class not reused for tests,
@@ -422,4 +434,5 @@ class ActsAsUrlIntegrationTest < Test::Unit::TestCase
     @doc = Document.create(title: "unique")
     assert_equal "unique-3", @doc.url
   end
+
 end


### PR DESCRIPTION
Current scope implementation fails if one or more of the scope attribute values is nil.

One may want to use nullable values as scope parameters when using stringex/acts_as_url in combination with a 'soft-delete' solution such as https://github.com/JackDanger/permanent_records

In this case, 'live' records will have a nil value for the deleted_at column, but deleted records will have a specific value. By including the deleted_at column in the acts_as_url scope, one can ensure that url slugs for live records will be unique, while also avoiding having 'deleted' records polluting the available URL space.
