### PR TITLE
Rails 6.1 removes update_attributes!. Use update! instead

### DIFF
--- a/test/unit/acts_as_url/adapter/activerecord.rb
+++ b/test/unit/acts_as_url/adapter/activerecord.rb
@@ -66,6 +66,6 @@ module AdapterSpecificTestBehaviors
   end
 
   def adapter_specific_update(instance, hash)
-    instance.send :update_attributes!, hash
+    instance.send :update!, hash
   end
 end

--- a/test/unit/acts_as_url/adapter/mongoid.rb
+++ b/test/unit/acts_as_url/adapter/mongoid.rb
@@ -77,6 +77,6 @@ module AdapterSpecificTestBehaviors
   end
 
   def adapter_specific_update(instance, hash)
-    instance.send :update_attributes!, hash
+    instance.send :update!, hash
   end
 end


### PR DESCRIPTION
According to
[this page](https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/),
rails 6.1 removed completely `update_attributes!` method. It has been renamed as `update!` for some time now.
This pull request makes this change in tests, to allow them to pass with ruby on rails 6.1.
