### PR TITLE
Support Ruby 2.7 arg syntax in callback_options

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -70,7 +70,11 @@ module Stringex
         end
 
         def create_callback
-          klass.send klass_callback_method, :ensure_unique_url, callback_options
+          klass.send(
+            klass_callback_method,
+            :ensure_unique_url,
+            **callback_options
+          )
         end
 
         def klass_callback_method


### PR DESCRIPTION
Fixes an issue in Ruby 3 and above where the callback options cause a NoMethodError.

```ruby
Error: test_should_truncate_words_by_default(ActsAsUrlIntegrationTest)a:
  NoMethodError: undefined method `before_validation' for [:on, :create]:Array

              target.send(method, *arguments, &block)
                    ^^^^^
```