### PR TITLE
Revert "Support Ruby 2.7 arg syntax in callback_options"

### DIFF
--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -70,11 +70,7 @@ module Stringex
         end
 
         def create_callback
-          klass.send(
-            klass_callback_method,
-            :ensure_unique_url,
-            **callback_options
-          )
+          klass.send klass_callback_method, :ensure_unique_url, callback_options
         end
 
         def klass_callback_method


### PR DESCRIPTION
Reverts rsl/stringex#208