### PR TITLE
Change transliteration of 汉

### DIFF
--- a/lib/stringex/unidecoder_data/x6c.yml
+++ b/lib/stringex/unidecoder_data/x6c.yml
@@ -72,7 +72,7 @@
 - 'Cuan '
 - 'Hui '
 - 'Diao '
-- 'Yi '
+- 'Han '
 - 'Cha '
 - 'Zhuo '
 - 'Chuan '

--- a/test/unit/unidecoder_test.rb
+++ b/test/unit/unidecoder_test.rb
@@ -48,7 +48,8 @@ class UnidecoderTest < Test::Unit::TestCase
     "私はガラスを食べられます。それは私を傷つけません。" => # Japanese
       "Si hagarasuwoShi beraremasu. sorehaSi woShang tukemasen. ",
     "⠋⠗⠁⠝⠉⠑" => # Braille
-      "france"
+      "france",
+    "武汉" => "Wu Han "
   }
 
   def test_unidecoder_decode


### PR DESCRIPTION
Currently, "武汉" is transliterated (via `to_url`) as "wu-yi". I have it on good authority that this is incorrect and should be transliterated as "wu-han", so this PR changes the transliteration of "汉" to "Han " and adds a test. 