### PR TITLE
Fix: Rails initializer callbacks used to prevent early loading

### DIFF
--- a/lib/stringex.rb
+++ b/lib/stringex.rb
@@ -10,7 +10,13 @@ require 'stringex/version'
 
 require 'stringex/core_ext'
 
-Stringex::ActsAsUrl::Adapter.load_available
+if defined?(::ActiveRecord) && defined?(::ActiveSupport)
+  ::ActiveSupport.on_load(:active_record) do
+    Stringex::ActsAsUrl::Adapter.load_available
+  end
+else
+  Stringex::ActsAsUrl::Adapter.load_available
+end
 
 if defined?(Rails::Railtie)
   require 'stringex/rails/railtie'


### PR DESCRIPTION
This fixes a loading issue, as Gems are not supposed to access Rails core classes (such as ActiveRecord::Base), during or before initialization.

See:
https://github.com/rails/rails/issues/52740

Not sure about the code, though, as we are not using acts_as_url or Mongoid etc.